### PR TITLE
Issue1에서 해결하지 못했던 Queue에 대한 라우팅 처리 @RabbitListener로 받는 작업 수정

### DIFF
--- a/src/main/java/com/rabbitmq/pratice/rabbitmq/config/RabbitMQConfig.java
+++ b/src/main/java/com/rabbitmq/pratice/rabbitmq/config/RabbitMQConfig.java
@@ -57,8 +57,8 @@ public class RabbitMQConfig {
      * @return
      */
     @Bean
-    public Queue queue() {
-        return new Queue(queueName,false);
+    public Queue chatQueue() {
+        return new Queue(queueName,true);
     }
 
     /**
@@ -72,13 +72,13 @@ public class RabbitMQConfig {
 
     /**
      * exchange 와 queue 사이의 바인딩을 하기 위한 라우팅키를 사용하여 빈 생성
-     * @param queue
+     * @param chatQueue
      * @param exchange
      * @return
      */
     @Bean
-    public Binding binding(Queue queue, TopicExchange exchange){
-        return BindingBuilder.bind(queue).to(exchange).with("chat.room.#");
+    public Binding binding(Queue chatQueue, TopicExchange exchange){
+        return BindingBuilder.bind(chatQueue).to(exchange).with("chat.room.#");
     }
 
     @Bean

--- a/src/main/java/com/rabbitmq/pratice/rabbitmq/service/RabbitMqService.java
+++ b/src/main/java/com/rabbitmq/pratice/rabbitmq/service/RabbitMqService.java
@@ -51,10 +51,16 @@ public class RabbitMqService {
         log.info("### send message  : {}",messageDto.toString());
         //stomp 전달하기 위함
         rabbitTemplate.convertAndSend(exchangeName,"chat.room."+messageDto.getRoomId(),messageDto);
-        if(messageDto.getGubun().equals("message")) {
-            //Listner에 담기 위함
-            rabbitTemplate.convertAndSend(queueName, messageDto);
-        }
+        // 기존에 잘 모르고 exchange에 해당하는 값을 수신하는 것이 아닌 queueName을 새로 지정한것으로 처리함
+        // 이유는 내가 잘 몰랐어서...
+        // 모르고 exchange에 대한 수신하는 queue에 대하여 규칙을 application.yml 에 선언된   queue.name의 값을 선언해 두어
+        // 위의 convertAndSend된 값을 제대로 받지 못하는 현상 발생
+        // 그래서 아래와 같이 명칭을 지정하여 다시 한번 send하는 불필요함을 진행... 이거는 정말 문제다...
+        // 그래도 다시 공부하니 좀 괜춘하네
+//        if(messageDto.getGubun().equals("message")) {
+//            //Listner에 담기 위함
+//            rabbitTemplate.convertAndSend(queueName, messageDto);
+//        }
     }
 
     /**
@@ -69,7 +75,11 @@ public class RabbitMqService {
 //
 //            )
 //    })
-    @RabbitListener(queues = "${rabbitmq.queue.name}")
+//    application.yml에 선언된 queue name을 따라간다는 것
+//    @RabbitListener(queues = "${rabbitmq.queue.name}")
+    // #{chatQueue.name}은 RabbitMQConfig.java에 선언된 chatQueue라는 Queue 명칭의 제목을 따라가는 것
+    // TopicExchange 타입의 Exchange를 이용하여 Routing key가 chat.room.#로 chat.room. 다음에 오는 모든 값에 대하여 receive 하겠다는 의미를 가짐
+    @RabbitListener(queues = "#{chatQueue.name}")
     public void receiveMessage(ChatMessage messageDto) throws Exception {
         log.info("### send message receive : {}",messageDto);
         if(messageDto.getGubun().equals("message")){


### PR DESCRIPTION
기존에 sendMessage 함수에서 exchangeName에 대한 publish 요청에 대한 subscribe가 제대로 진행되지 않았던 이슈가 발생하여, queueName에 대한 publish를 한번더 전송하는 비효율성이 존재.. 이러한 문제를 해결하기위해 RabbitMQConfig에 대한 공부를 다시 하였고, @Bean으로 선언된 Queue에 대한 명칭을 @RabbitListener에서 사용할 수 있도록 해야한다는 것을 알게됨 기존에는 application.yml에 선언된 queue.name 을 선언하였지만 그렇게 해서는 해당 명칭에 해당하는 메세지만을 receive할 수 있고 exchangeName에 선언된 라우팅 키 값 기준으로는 receive 받지 못함,

그렇기 때문에 ${} 이것이 아닌 #{}를 선언하여 @Bean Queue 객체의 메소드 이름인 chatQueue.name을 선언해야 해당 라운팅 키값을 기준으로 받아 볼 수 있음 그에 대한 수정을 적용